### PR TITLE
readme: fix typo in delete example, kind: commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Jetstream Commits have 3 `operations`:
 {
   "did": "did:plc:rfov6bpyztcnedeyyzgfq42k",
   "time_us": 1725516666833633,
-  "type": "commit",
+  "kind": "commit",
   "commit": {
     "rev": "3l3f6nzl3cv2s",
     "operation": "delete",


### PR DESCRIPTION
Hi @ericvolp12! Tiny typo fix. Looks like this is the right repo now, not your personal one. Looking forward to trying out jetstream, thanks again for building it!