### PR TITLE
Return errors from client.ConnectAndRead read loop

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -116,9 +116,11 @@ func (c *Client) ConnectAndRead(ctx context.Context, cursor *int64) error {
 	c.con = con
 
 	if err := c.readLoop(ctx); err != nil {
-		c.logger.Error("read loop failed", "error", err)
-	} else {
-		c.con.Close()
+		return fmt.Errorf("read loop failed: %w", err)
+	}
+
+	if err := c.con.Close(); err != nil {
+		return fmt.Errorf("failed to close connection: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Makes client.ConnectAndRead return an error if the read loop fails, so the caller can distinguish an orderly shutdown (triggered by context completion or the client shutdown channel) from an unexpected error.

Not sure if the `c.logger.Error` call should also be kept, I'm pretty new to Go so don't know what would be conventional here.