### PR TITLE
Add maxMessageSizeBytes subscriber option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following Query Parameters are supported:
   - You can specify at most 100 wanted collections/prefixes.
 - `wantedDids` - An array of Repo DIDs to filter which records you receive on your stream (Default empty = all repos)
   - You can specify at most 10,000 wanted DIDs.
-- `maxSize` - The maximum size in bytes for a payload that this client would like to receive. Zero means no limit, negative values are treated as zero. (Default "0" or empty = no maximum size)
+- `maxMessageSizeBytes` - The maximum size of a payload that this client would like to receive. Zero means no limit, negative values are treated as zero. (Default "0" or empty = no maximum size)
 - `cursor` - A unix microseconds timestamp cursor to begin playback from
   - An absent cursor or a cursor from the future will result in live-tail operation
   - When reconnecting, use the `time_us` from your most recently processed event and maybe provide a negative buffer (i.e. subtract a few seconds) to ensure gapless playback
@@ -198,9 +198,9 @@ The shape for a `SubscriberOptionsUpdatePayload` is as follows:
 
 ```go
 type SubscriberOptionsUpdateMsg struct {
-	WantedCollections []string `json:"wantedCollections"`
-	WantedDIDs        []string `json:"wantedDids"`
-	MaxSize           int      `json:"maxSize"`
+	WantedCollections   []string `json:"wantedCollections"`
+	WantedDIDs          []string `json:"wantedDids"`
+	MaxMessageSizeBytes int      `json:"maxMessageSizeBytes"`
 }
 ```
 
@@ -220,7 +220,7 @@ An example Subscriber Sourced Message with an Options Update payload is as follo
   "payload": {
     "wantedCollections": ["app.bsky.feed.post"],
     "wantedDids": ["did:plc:q6gjnaw2blty4crticxkmujt"],
-    "maxSize": 1000000
+    "maxMessageSizeBytes": 1000000
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following Query Parameters are supported:
   - You can specify at most 100 wanted collections/prefixes.
 - `wantedDids` - An array of Repo DIDs to filter which records you receive on your stream (Default empty = all repos)
   - You can specify at most 10,000 wanted DIDs.
-- `maxSize` - The maximum size of a payload that this client would like to receive. Zero means no limit, negative values are treated as zero. (Default "0" or empty = no maximum size)
+- `maxSize` - The maximum size in bytes for a payload that this client would like to receive. Zero means no limit, negative values are treated as zero. (Default "0" or empty = no maximum size)
 - `cursor` - A unix microseconds timestamp cursor to begin playback from
   - An absent cursor or a cursor from the future will result in live-tail operation
   - When reconnecting, use the `time_us` from your most recently processed event and maybe provide a negative buffer (i.e. subtract a few seconds) to ensure gapless playback

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The shape for a `SubscriberOptionsUpdatePayload` is as follows:
 type SubscriberOptionsUpdateMsg struct {
 	WantedCollections []string `json:"wantedCollections"`
 	WantedDIDs        []string `json:"wantedDids"`
-    MaxSize           int      `json:"maxSize"`
+	MaxSize           int      `json:"maxSize"`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following Query Parameters are supported:
   - You can specify at most 100 wanted collections/prefixes.
 - `wantedDids` - An array of Repo DIDs to filter which records you receive on your stream (Default empty = all repos)
   - You can specify at most 10,000 wanted DIDs.
+- `maxSize` - The maximum size of a payload that this client would like to receive. Zero means no limit, negative values are treated as zero. (Default "0" or empty = no maximum size)
 - `cursor` - A unix microseconds timestamp cursor to begin playback from
   - An absent cursor or a cursor from the future will result in live-tail operation
   - When reconnecting, use the `time_us` from your most recently processed event and maybe provide a negative buffer (i.e. subtract a few seconds) to ensure gapless playback
@@ -199,6 +200,7 @@ The shape for a `SubscriberOptionsUpdatePayload` is as follows:
 type SubscriberOptionsUpdateMsg struct {
 	WantedCollections []string `json:"wantedCollections"`
 	WantedDIDs        []string `json:"wantedDids"`
+    MaxSize           int      `json:"maxSize"`
 }
 ```
 
@@ -217,7 +219,8 @@ An example Subscriber Sourced Message with an Options Update payload is as follo
   "type": "options_update",
   "payload": {
     "wantedCollections": ["app.bsky.feed.post"],
-    "wantedDids": ["did:plc:q6gjnaw2blty4crticxkmujt"]
+    "wantedDids": ["did:plc:q6gjnaw2blty4crticxkmujt"],
+    "maxSize": 1000000
   }
 }
 ```

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -31,6 +31,7 @@ func main() {
 	config.WebsocketURL = serverAddr
 	config.Compress = true
 
+	h := handler{}
 	scheduler := sequential.NewScheduler("jetstream_localdev", logger, h.HandleEvent)
 
 	c, err := client.NewClient(config, logger, scheduler)

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -194,7 +194,7 @@ func Jetstream(cctx *cli.Context) error {
 			case <-ticker.C:
 				seq, _ := c.Progress.Get()
 				if seq == lastSeq && seq != 0 {
-					log.Error("no new events in last "+ cctx.Duration("liveness-ttl").String() +", shutting down for docker to restart me", "seq", seq)
+					log.Error("no new events in last "+cctx.Duration("liveness-ttl").String()+", shutting down for docker to restart me", "seq", seq)
 					close(livenessKill)
 				} else {
 					// Trim the database

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/labstack/gommon v0.4.1
 	github.com/prometheus/client_golang v1.19.1
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.26.0
 	go.opentelemetry.io/otel v1.21.0
 	go.uber.org/atomic v1.11.0
@@ -32,6 +33,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/getsentry/sentry-go v0.28.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -90,6 +92,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.1-0.20221221234430-40501e09de1f // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.54.0 // indirect
@@ -114,6 +117,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.5.7 // indirect
 	gorm.io/gorm v1.25.9 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -101,8 +102,6 @@ require (
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
 	github.com/whyrusleeping/cbor-gen v0.1.3-0.20240904181319-8dc02b38228c // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
-	gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b // indirect
-	gitlab.com/yawning/tuplehash v0.0.0-20230713102510-df83abbf9a02 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,6 +19,7 @@ type ClientConfig struct {
 	WebsocketURL      string
 	WantedDids        []string
 	WantedCollections []string
+	MaxSize           uint32
 	ExtraHeaders      map[string]string
 }
 
@@ -44,6 +45,7 @@ func DefaultClientConfig() *ClientConfig {
 		WebsocketURL:      "ws://localhost:6008/subscribe",
 		WantedDids:        []string{},
 		WantedCollections: []string{},
+		MaxSize:           0,
 		ExtraHeaders: map[string]string{
 			"User-Agent": "jetstream-client/v0.0.1",
 		},
@@ -93,6 +95,10 @@ func (c *Client) ConnectAndRead(ctx context.Context, cursor *int64) error {
 
 	for _, collection := range c.config.WantedCollections {
 		params = append(params, fmt.Sprintf("wantedCollections=%s", collection))
+	}
+
+	if c.config.MaxSize > 0 {
+		params = append(params, fmt.Sprintf("maxSize=%d", c.config.MaxSize))
 	}
 
 	if len(params) > 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,8 +66,8 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 	qWantedCollections := c.Request().URL.Query()["wantedCollections"]
 	qWantedDids := c.Request().URL.Query()["wantedDids"]
 
-	qMaxSize := c.Request().URL.Query().Get("maxSize")
-	qMaxSizeValue := ParseMaxSize(qMaxSize)
+	qMaxMessageSizeBytes := c.Request().URL.Query().Get("maxMessageSizeBytes")
+	qMaxMessageSizeBytesValue := ParseMaxMessageSizeBytes(qMaxMessageSizeBytes)
 
 	// Check if the user wants to initialize options over the websocket before subscribing
 	requireHello := c.Request().URL.Query().Get("requireHello") == "true"
@@ -95,7 +95,7 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 	}
 
 	// Parse the subscriber options
-	subscriberOpts, err := parseSubscriberOptions(ctx, qWantedCollections, qWantedDids, compress, qMaxSizeValue, cursor)
+	subscriberOpts, err := parseSubscriberOptions(ctx, qWantedCollections, qWantedDids, compress, qMaxMessageSizeBytesValue, cursor)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return err
@@ -166,10 +166,10 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 						return
 					}
 
-					maxSize := ParseMaxSize(subOptsUpdate.MaxSize)
+					maxMessageSizeBytes := ParseMaxMessageSizeBytes(subOptsUpdate.MaxMessageSizeBytes)
 					// Only WantedCollections and WantedDIDs can be updated after the initial connection
 					// Cursor and Compression settings are fixed for the lifetime of the stream
-					subscriberOpts, err = parseSubscriberOptions(ctx, subOptsUpdate.WantedCollections, subOptsUpdate.WantedDIDs, compress, maxSize, sub.cursor)
+					subscriberOpts, err = parseSubscriberOptions(ctx, subOptsUpdate.WantedCollections, subOptsUpdate.WantedDIDs, compress, maxMessageSizeBytes, sub.cursor)
 					if err != nil {
 						log.Error("failed to parse subscriber options", "error", err, "new_opts", subOptsUpdate)
 						sub.Terminate(fmt.Sprintf("failed to parse subscriber options: %v", err))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,9 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 	qWantedCollections := c.Request().URL.Query()["wantedCollections"]
 	qWantedDids := c.Request().URL.Query()["wantedDids"]
 
+	qMaxSize := c.Request().URL.Query().Get("maxSize")
+	qMaxSizeValue := ParseMaxSize(qMaxSize)
+
 	// Check if the user wants to initialize options over the websocket before subscribing
 	requireHello := c.Request().URL.Query().Get("requireHello") == "true"
 
@@ -92,7 +95,7 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 	}
 
 	// Parse the subscriber options
-	subscriberOpts, err := parseSubscriberOptions(ctx, qWantedCollections, qWantedDids, compress, cursor)
+	subscriberOpts, err := parseSubscriberOptions(ctx, qWantedCollections, qWantedDids, compress, qMaxSizeValue, cursor)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return err
@@ -163,9 +166,10 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 						return
 					}
 
+					maxSize := ParseMaxSize(subOptsUpdate.MaxSize)
 					// Only WantedCollections and WantedDIDs can be updated after the initial connection
 					// Cursor and Compression settings are fixed for the lifetime of the stream
-					subscriberOpts, err = parseSubscriberOptions(ctx, subOptsUpdate.WantedCollections, subOptsUpdate.WantedDIDs, compress, sub.cursor)
+					subscriberOpts, err = parseSubscriberOptions(ctx, subOptsUpdate.WantedCollections, subOptsUpdate.WantedDIDs, compress, maxSize, sub.cursor)
 					if err != nil {
 						log.Error("failed to parse subscriber options", "error", err, "new_opts", subOptsUpdate)
 						sub.Terminate(fmt.Sprintf("failed to parse subscriber options: %v", err))

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -66,7 +66,7 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 	}
 
 	evtBytes := getEventBytes()
-	if sub.maxSize > 0 && len(evtBytes) > int(sub.maxSize) {
+	if sub.maxSize > 0 && uint32(len(evtBytes)) > sub.maxSize {
 		return nil
 	}
 

--- a/pkg/server/subscriber_test.go
+++ b/pkg/server/subscriber_test.go
@@ -8,47 +8,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseMaxSize(t *testing.T) {
+func TestParseMaxMessageSizeBytes(t *testing.T) {
 	stringTests := []struct {
-		name     string
-		maxSize  string
-		expected uint32
+		name                string
+		maxMessageSizeBytes string
+		expected            uint32
 	}{
 		{
-			name:     "zero",
-			maxSize:  "0",
-			expected: 0,
+			name:                "zero",
+			maxMessageSizeBytes: "0",
+			expected:            0,
 		},
 		{
-			name:     "empty",
-			maxSize:  "",
-			expected: 0,
+			name:                "empty",
+			maxMessageSizeBytes: "",
+			expected:            0,
 		},
 		{
-			name:     "invalid",
-			maxSize:  "nope",
-			expected: 0,
+			name:                "invalid",
+			maxMessageSizeBytes: "nope",
+			expected:            0,
 		},
 		{
-			name:     "valid",
-			maxSize:  "1000000",
-			expected: 1000000,
+			name:                "valid",
+			maxMessageSizeBytes: "1000000",
+			expected:            1000000,
 		},
 		{
-			name:     "uint32max",
-			maxSize:  "4294967295",
-			expected: 4294967295,
+			name:                "uint32max",
+			maxMessageSizeBytes: "4294967295",
+			expected:            4294967295,
 		},
 		{
-			name:     "uint32max_plus1",
-			maxSize:  "4294967296",
-			expected: 0,
+			name:                "uint32max_plus1",
+			maxMessageSizeBytes: "4294967296",
+			expected:            0,
 		},
 	}
 
 	for _, tt := range stringTests {
 		t.Run(fmt.Sprintf("string %s", tt.name), func(t *testing.T) {
-			got := ParseMaxSize(tt.maxSize)
+			got := ParseMaxMessageSizeBytes(tt.maxMessageSizeBytes)
 			if got != tt.expected {
 				t.Errorf("expected max size to be %d, got %d", tt.expected, got)
 			}
@@ -56,30 +56,30 @@ func TestParseMaxSize(t *testing.T) {
 	}
 
 	intTests := []struct {
-		name     string
-		maxSize  int
-		expected uint32
+		name                string
+		maxMessageSizeBytes int
+		expected            uint32
 	}{
 		{
-			name:     "zero",
-			maxSize:  0,
-			expected: 0,
+			name:                "zero",
+			maxMessageSizeBytes: 0,
+			expected:            0,
 		},
 		{
-			name:     "uint32max",
-			maxSize:  4294967295,
-			expected: 4294967295,
+			name:                "uint32max",
+			maxMessageSizeBytes: 4294967295,
+			expected:            4294967295,
 		},
 		{
-			name:     "uint32max_plus1",
-			maxSize:  4294967296,
-			expected: 0,
+			name:                "uint32max_plus1",
+			maxMessageSizeBytes: 4294967296,
+			expected:            0,
 		},
 	}
 
 	for _, tt := range intTests {
 		t.Run(fmt.Sprintf("int %s", tt.name), func(t *testing.T) {
-			got := ParseMaxSize(tt.maxSize)
+			got := ParseMaxMessageSizeBytes(tt.maxMessageSizeBytes)
 			if got != tt.expected {
 				t.Errorf("expected max size to be %d, got %d", tt.expected, got)
 			}
@@ -97,27 +97,27 @@ func TestParseSubscriberOptions(t *testing.T) {
 			name: "empty",
 			data: []byte(`{}`),
 			expected: SubscriberOptionsUpdatePayload{
-				WantedCollections: nil,
-				WantedDIDs:        nil,
-				MaxSize:           0,
+				WantedCollections:   nil,
+				WantedDIDs:          nil,
+				MaxMessageSizeBytes: 0,
 			},
 		},
 		{
 			name: "collection",
 			data: []byte(`{"wantedCollections":["foo"]}`),
 			expected: SubscriberOptionsUpdatePayload{
-				WantedCollections: []string{"foo"},
-				WantedDIDs:        nil,
-				MaxSize:           0,
+				WantedCollections:   []string{"foo"},
+				WantedDIDs:          nil,
+				MaxMessageSizeBytes: 0,
 			},
 		},
 		{
 			name: "small",
-			data: []byte(`{"maxSize":1000}`),
+			data: []byte(`{"maxMessageSizeBytes":1000}`),
 			expected: SubscriberOptionsUpdatePayload{
-				WantedCollections: nil,
-				WantedDIDs:        nil,
-				MaxSize:           1000,
+				WantedCollections:   nil,
+				WantedDIDs:          nil,
+				MaxMessageSizeBytes: 1000,
 			},
 		},
 	}

--- a/pkg/server/subscriber_test.go
+++ b/pkg/server/subscriber_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMaxSize(t *testing.T) {
+	stringTests := []struct {
+		name     string
+		maxSize  string
+		expected uint32
+	}{
+		{
+			name:     "zero",
+			maxSize:  "0",
+			expected: 0,
+		},
+		{
+			name:     "empty",
+			maxSize:  "",
+			expected: 0,
+		},
+		{
+			name:     "invalid",
+			maxSize:  "nope",
+			expected: 0,
+		},
+		{
+			name:     "valid",
+			maxSize:  "1000000",
+			expected: 1000000,
+		},
+		{
+			name:     "uint32max",
+			maxSize:  "4294967295",
+			expected: 4294967295,
+		},
+		{
+			name:     "uint32max_plus1",
+			maxSize:  "4294967296",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range stringTests {
+		t.Run(fmt.Sprintf("string %s", tt.name), func(t *testing.T) {
+			got := ParseMaxSize(tt.maxSize)
+			if got != tt.expected {
+				t.Errorf("expected max size to be %d, got %d", tt.expected, got)
+			}
+		})
+	}
+
+	intTests := []struct {
+		name     string
+		maxSize  int
+		expected uint32
+	}{
+		{
+			name:     "zero",
+			maxSize:  0,
+			expected: 0,
+		},
+		{
+			name:     "uint32max",
+			maxSize:  4294967295,
+			expected: 4294967295,
+		},
+		{
+			name:     "uint32max_plus1",
+			maxSize:  4294967296,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range intTests {
+		t.Run(fmt.Sprintf("int %s", tt.name), func(t *testing.T) {
+			got := ParseMaxSize(tt.maxSize)
+			if got != tt.expected {
+				t.Errorf("expected max size to be %d, got %d", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseSubscriberOptions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected SubscriberOptionsUpdatePayload
+	}{
+		{
+			name: "empty",
+			data: []byte(`{}`),
+			expected: SubscriberOptionsUpdatePayload{
+				WantedCollections: nil,
+				WantedDIDs:        nil,
+				MaxSize:           0,
+			},
+		},
+		{
+			name: "collection",
+			data: []byte(`{"wantedCollections":["foo"]}`),
+			expected: SubscriberOptionsUpdatePayload{
+				WantedCollections: []string{"foo"},
+				WantedDIDs:        nil,
+				MaxSize:           0,
+			},
+		},
+		{
+			name: "small",
+			data: []byte(`{"maxSize":1000}`),
+			expected: SubscriberOptionsUpdatePayload{
+				WantedCollections: nil,
+				WantedDIDs:        nil,
+				MaxSize:           1000,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var subOptsUpdate SubscriberOptionsUpdatePayload
+			if err := json.Unmarshal(testCase.data, &subOptsUpdate); err != nil {
+				t.Errorf("failed to unmarshal subscriber options update: %v", err)
+			}
+			assert.Equal(t, subOptsUpdate, testCase.expected)
+		})
+	}
+
+}


### PR DESCRIPTION
This PR introduces the `maxMessageSizeBytes` subscriber option, allowing jetstream consumers to opt-in to ignoring potentially large payloads.

* [x] Added tests
* [x] Updated readme - [rendered README.md](https://github.com/bluesky-social/jetstream/blob/5336fb1683559dc38fcbe51a1fbb61e388116130/README.md)
* [x] Added documentation to exported methods