### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following Query Parameters are supported:
 A simple example that hits the public instance looks like:
 
 ```bash
-$ websocat wss://jetstream2.us-east.bsky.network/subscribe\?wantedCollections=app.bsky.feed.post
+$ websocat wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post
 ```
 
 A maximal example using all parameters looks like:


### PR DESCRIPTION
This pull request removes a backslash that I am assuming is here by mistake. Due to being very minimal, I didn't see an issue being necessary but happy to create one if needed.