### PR TITLE
Add per-IP rate limiters

### DIFF
--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -195,6 +195,12 @@ func (s *Server) AddSubscriber(ws *websocket.Conn, realIP string, opts *Subscrib
 	s.lk.Lock()
 	defer s.lk.Unlock()
 
+	lim := s.perIPLimiters[realIP]
+	if lim == nil {
+		lim = rate.NewLimiter(rate.Limit(s.maxSubRate), int(s.maxSubRate))
+		s.perIPLimiters[realIP] = lim
+	}
+
 	sub := Subscriber{
 		ws:                ws,
 		realIP:            realIP,
@@ -207,7 +213,7 @@ func (s *Server) AddSubscriber(ws *websocket.Conn, realIP string, opts *Subscrib
 		compress:          opts.Compress,
 		deliveredCounter:  eventsDelivered.WithLabelValues(realIP),
 		bytesCounter:      bytesDelivered.WithLabelValues(realIP),
-		rl:                rate.NewLimiter(rate.Limit(s.maxSubRate), int(s.maxSubRate)),
+		rl:                lim,
 	}
 
 	s.Subscribers[s.nextSub] = &sub


### PR DESCRIPTION
Seeing some weird behavior where some consumers will reconnect very aggressively like multiple times a second and trigger huge playbacks but half close the connection and open a new one. This sucks and I'll start with a basic IP-wide rate limiter but may move to rejecting connections if I see too many for one IP at some point.