### PR TITLE
Add the sequence number to `commit` events.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ run: .env
 	@echo "Running Jetstream..."
 	$(GO_CMD_W_CGO) run cmd/jetstream/*.go
 
+.PHONY: test
+test:
+	@echo "Testing Jestream..."
+	$(GO_CMD_W_CGO) test ./...
+
 .PHONY: up
 up:
 	@echo "Starting Jetstream..."

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Jetstream Commits have 3 `operations`:
         "uri": "at://did:plc:wa7b35aakoll7hugkrjtf3xf/app.bsky.feed.post/3l3pte3p2e325"
       }
     },
-    "cid": "bafyreidwaivazkwu67xztlmuobx35hs2lnfh3kolmgfmucldvhd3sgzcqi"
+    "cid": "bafyreidwaivazkwu67xztlmuobx35hs2lnfh3kolmgfmucldvhd3sgzcqi",
+    "seq": 3012084059
   }
 }
 ```
@@ -126,7 +127,8 @@ Jetstream Commits have 3 `operations`:
     "rev": "3l3f6nzl3cv2s",
     "operation": "delete",
     "collection": "app.bsky.graph.follow",
-    "rkey": "3l3dn7tku762u"
+    "rkey": "3l3dn7tku762u",
+    "seq": 3012071933
   }
 }
 ```

--- a/pkg/consumer/consumer.go
+++ b/pkg/consumer/consumer.go
@@ -274,6 +274,7 @@ func (c *Consumer) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSub
 				RKey:       rkey,
 				Record:     recJSON,
 				CID:        recCid,
+				Seq:	    evt.Seq,
 			}
 		case repomgr.EvtKindUpdateRecord:
 			if op.Cid == nil {
@@ -312,6 +313,7 @@ func (c *Consumer) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSub
 				RKey:       rkey,
 				Record:     recJSON,
 				CID:        recCid,
+				Seq:	    evt.Seq,
 			}
 		case repomgr.EvtKindDeleteRecord:
 			// Emit the delete
@@ -320,6 +322,7 @@ func (c *Consumer) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSub
 				Operation:  models.CommitOperationDelete,
 				Collection: collection,
 				RKey:       rkey,
+				Seq:	    evt.Seq,
 			}
 		default:
 			log.Warn("unknown event kind from op action", "kind", op.Action)

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -27,6 +27,7 @@ type Commit struct {
 	RKey       string          `json:"rkey,omitempty"`
 	Record     json.RawMessage `json:"record,omitempty"`
 	CID        string          `json:"cid,omitempty"`
+	Seq	   int64	   `json:"seq,omitempty"`
 }
 
 var (


### PR DESCRIPTION
This already exists in [`account`](https://github.com/bluesky-social/indigo/blob/ad3c38b9139c4ccd511513a8e17cbcc21e77c18a/api/atproto/syncsubscribeRepos.go#L18) and [`indentity`](https://github.com/bluesky-social/indigo/blob/ad3c38b9139c4ccd511513a8e17cbcc21e77c18a/api/atproto/syncsubscribeRepos.go#L69) events, so this makes `commit` more consistent.

This is useful for places like https://github.com/bluesky-social/feed-generator/blob/c14c54bd65eb2ea638e0be4303a4b1af53a211a6/src/util/subscription.ts#L46

This also adds a make target to run the (minimal) tests.