### PR TITLE
Fix data race of sub.seq during replay -> live tail cutover

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -215,6 +215,8 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 		go func() {
 			for {
 				lastSeq, err := s.Consumer.ReplayEvents(ctx, sub.compress, *sub.cursor, playbackRateLimit, func(ctx context.Context, timeUS int64, did, collection string, getEventBytes func() []byte) error {
+					sub.lk.Lock()
+					defer sub.lk.Unlock()
 					return emitToSubscriber(ctx, log, sub, timeUS, did, collection, true, getEventBytes)
 				})
 				if err != nil {

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -49,6 +49,7 @@ type Subscriber struct {
 // emitToSubscriber sends an event to a subscriber if the subscriber wants the event
 // It takes a valuer function to get the event bytes so that the caller can avoid
 // unnecessary allocations and/or reading from the playback DB if the subscriber doesn't want the event
+// Callers must lock the subscriber before calling this function to avoid data race with sub.seq
 func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, timeUS int64, did, collection string, playback bool, getEventBytes func() []byte) error {
 	if !sub.WantsCollection(collection) {
 		return nil


### PR DESCRIPTION
Prevent a data race that leads to out-of-order events being delivered during cutover from replay to live-tailing, partially resolving [#42](https://github.com/bluesky-social/jetstream/issues/42).

`emitToSubscriber` [reads and writes `sub.seq`](https://github.com/bluesky-social/jetstream/blob/ea96859b93d1790ff20bb168e5fc442d462cea1e/pkg/server/subscriber.go#L63-L103), but does not itself lock the subscriber's `sub.lk`. It can't, because its main caller, the server `Emit` function, [takes that lock across](https://github.com/bluesky-social/jetstream/blob/ea96859b93d1790ff20bb168e5fc442d462cea1e/pkg/server/server.go#L309-L323) its call to `emitToSubscriber`.

The other caller is the replay goroutine, which runs concurrently, and [did not take the lock](https://github.com/bluesky-social/jetstream/blob/ea96859b93d1790ff20bb168e5fc442d462cea1e/pkg/server/server.go#L218), leaving `sub.seq` exposed to races when both it and `Emit` ran concurrently (for ~0.5s during cutover).

This change makes the replay goroutine take the lock before calling `emitToSubscriber`, protecting `sub.seq` from this race.

---

I've verified locally that jetstream still works and cuts over, and created a pair of repro scripts that (try to) trigger the data race: https://gist.github.com/uniphil/346acb62088022729394d2324bf2ad8a

With the changes from this PR, the local repro goes from almost always triggering the race to never in all tests so far -- see sample output in the linked gist. I'll verify prod again if this gets merged and deployed 🙂