### PR TITLE
Add client-driven heartbeat message/event support

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -206,8 +206,8 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 						cancel()
 						return
 					}
-					eventJSON, err := json.Marshal(SubscriberHeartbeatServerEvent {
-						Kind: SubMessageHeartbeat,
+					eventJSON, err := json.Marshal(SubscriberHeartbeatServerEvent{
+						Kind:    SubMessageHeartbeat,
 						Payload: subHeartbeatPayload,
 					})
 					if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,10 @@ var maxConcurrentEmits = int64(100)
 var cutoverThresholdUS = int64(1_000_000)
 var tracer = otel.Tracer("jetstream-server")
 
+// WebSocket frame is 125 bytes and we need room for Text frame overhead + JSON
+// 81 is just a nice number.
+var maxHeartbeatPayload = int(81)
+
 func NewServer(maxSubRate float64) (*Server, error) {
 	s := Server{
 		Subscribers:   make(map[int64]*Subscriber),
@@ -185,6 +189,37 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 					if requireHello {
 						sub.hello <- struct{}{}
 						requireHello = false
+					}
+				case SubMessageHeartbeat:
+					payloadSize := len(subMessage.Payload)
+					if payloadSize > maxHeartbeatPayload {
+						log.Error("received heartbeat message with too-large payload", "len", payloadSize)
+						sub.Terminate(fmt.Sprintf("heartbeat payload of %d bytes is too large. maximum is %d", payloadSize, maxHeartbeatPayload))
+						cancel()
+						return
+					}
+					// we don't really *need* to force that it's a string (and not other JSON) but let's be strict
+					var subHeartbeatPayload SubscriberHeartbeatPayload
+					if err := json.Unmarshal(subMessage.Payload, &subHeartbeatPayload); err != nil {
+						log.Error("failed to unmarshal heartbeat payload", "error", err, "msg", string(msgBytes))
+						sub.Terminate(fmt.Sprintf("failed to unmarshal heartbeat payload: %v", err))
+						cancel()
+						return
+					}
+					eventJSON, err := json.Marshal(SubscriberHeartbeatServerEvent {
+						Kind: SubMessageHeartbeat,
+						Payload: subHeartbeatPayload,
+					})
+					if err != nil {
+						log.Error("failed to marshal heartbeat event", "error", err, "payload", string(subHeartbeatPayload))
+						sub.Terminate(fmt.Sprintf("failed to marshal heartbeat payload: %v", err))
+						cancel()
+						return
+					}
+					if err := sub.WriteMessage(websocket.TextMessage, eventJSON); err != nil {
+						log.Error("failed to write heartbeat to websocket", "error", err)
+						cancel()
+						return
 					}
 				default:
 					log.Warn("received unexpected message type from client, ignoring", "type", subMessage.Type)

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -136,10 +136,10 @@ type SubscriberOptionsUpdatePayload struct {
 	MaxMessageSizeBytes int      `json:"maxMessageSizeBytes"`
 }
 
-type SubscriberHeartbeatPayload = string;
+type SubscriberHeartbeatPayload = string
 
 type SubscriberHeartbeatServerEvent struct {
-	Kind	string `json:"kind"`
+	Kind    string                     `json:"kind"`
 	Payload SubscriberHeartbeatPayload `json:"payload"`
 }
 

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -123,6 +123,7 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 }
 
 var SubMessageOptionsUpdate = "options_update"
+var SubMessageHeartbeat = "heartbeat"
 
 type SubscriberSourcedMessage struct {
 	Type    string          `json:"type"`
@@ -133,6 +134,13 @@ type SubscriberOptionsUpdatePayload struct {
 	WantedCollections   []string `json:"wantedCollections"`
 	WantedDIDs          []string `json:"wantedDids"`
 	MaxMessageSizeBytes int      `json:"maxMessageSizeBytes"`
+}
+
+type SubscriberHeartbeatPayload = string;
+
+type SubscriberHeartbeatServerEvent struct {
+	Kind	string `json:"kind"`
+	Payload SubscriberHeartbeatPayload `json:"payload"`
 }
 
 type SubscriberOptions struct {


### PR DESCRIPTION
WebSocket client APIs in web browsers and some javascript environments (like bun) do not expose ping/pong APIs, and may not initiate pings themselves. This can lead to stale connections that don't properly close for a long time for apps in those environments.

This change adds a new `heartbeat` client message type, and a new `heartbeat` event kind. It behaves very close to WebSocket ping/pong -- immediate response, an optional `payload` string can be passed, etc.

Doing heartbeats at the app level should help client apps in these environments detect a dead connection faster. (clients with access to ping/pong should of course prefer those instead)

<details>
<summary>lil local browser test script</summary>

```js
ws = new WebSocket('ws://localhost:6008/subscribe?wantedCollections=non.existent.thing');

n = 0;

ws.addEventListener('open', (event) => {
  console.log('sup hi');

  setInterval(() => {
      ws.send(JSON.stringify({
        type: 'heartbeat',
        payload: n === 0 ? '' : ''+n,
      }));
      n += 1;
    },
    500);
});

ws.addEventListener('message', (event) => {
  const { data } = event;
  const stuff = JSON.parse(data);
  if (['identity', 'account'].includes(stuff.kind)) return;

  console.log('from server ', event.data);
});

ws.addEventListener('error', e => {
  console.log('ws error', e);
});

ws.addEventListener('close', m => {
  console.log('ws close', m);
});

```

this will first do an empty-payload heartbeat, and then vary the payload with an increasing number every 500ms. i tested type errors and length errors by adjusting the `payload` here.

</details>