### PR TITLE
Fixes setting max message size option with subscribers

### DIFF
--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -212,18 +212,19 @@ func (s *Server) AddSubscriber(ws *websocket.Conn, realIP string, opts *Subscrib
 	}
 
 	sub := Subscriber{
-		ws:                ws,
-		realIP:            realIP,
-		outbox:            make(chan *[]byte, 50_000),
-		hello:             make(chan struct{}),
-		id:                s.nextSub,
-		wantedCollections: opts.WantedCollections,
-		wantedDids:        opts.WantedDIDs,
-		cursor:            opts.Cursor,
-		compress:          opts.Compress,
-		deliveredCounter:  eventsDelivered.WithLabelValues(realIP),
-		bytesCounter:      bytesDelivered.WithLabelValues(realIP),
-		rl:                lim,
+		ws:                  ws,
+		realIP:              realIP,
+		outbox:              make(chan *[]byte, 50_000),
+		hello:               make(chan struct{}),
+		id:                  s.nextSub,
+		wantedCollections:   opts.WantedCollections,
+		wantedDids:          opts.WantedDIDs,
+		cursor:              opts.Cursor,
+		compress:            opts.Compress,
+		maxMessageSizeBytes: opts.MaxMessageSizeBytes,
+		deliveredCounter:    eventsDelivered.WithLabelValues(realIP),
+		bytesCounter:        bytesDelivered.WithLabelValues(realIP),
+		rl:                  lim,
 	}
 
 	s.Subscribers[s.nextSub] = &sub


### PR DESCRIPTION
Sets `maxMessageSizeBytes` for a `Subscriber` based on options passed. Resolves #49 


### bluesky-social:main

```
$ git rev-parse --short HEAD
f4da85b
$ websocat --buffer-size 5048576  'ws://localhost:6008/subscribe?cursor=1744574157413328&maxMessageSizeBytes=400' | head -n20 | awk '{print length}'
502
712
394
394
502
394
196
502
383
502
394
196
394
502
394
199
502
394
502
502
websocat: other error
websocat: error running
```

### robpc:fix-max-message-size

without param
```
$ websocat --buffer-size 5048576  'ws://localhost:6008/subscribe?cursor=1744574157413328' | hea
d -n20 | awk '{print length}'
502
712
394
394
502
394
196
502
383
502
394
196
394
502
394
199
502
394
502
502
websocat: other error
websocat: error running
```

with param
```
$ websocat --buffer-size 5048576  'ws://localhost:6008/subscribe?cursor=1744574157413328&maxMessageSizeBytes=400' | head -n20 | awk '{print length}'
394
394
394
196
383
394
196
394
394
199
394
392
394
394
394
websocat: other error
websocat: error running
394
394
394
394
394
```