### PR TITLE
Add configurable read timeout for the client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -73,6 +73,10 @@ func NewClient(config *ClientConfig, logger *slog.Logger, scheduler Scheduler) (
 		Scheduler: scheduler,
 	}
 
+	if config.ExtraHeaders == nil {
+		config.ExtraHeaders = map[string]string{}
+	}
+
 	if config.Compress {
 		c.config.ExtraHeaders["Socket-Encoding"] = "zstd"
 		dec, err := zstd.NewReader(nil, zstd.WithDecoderDicts(models.ZSTDDictionary))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,12 +7,17 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/bluesky-social/jetstream/pkg/models"
 	"github.com/goccy/go-json"
 	"github.com/gorilla/websocket"
 	"github.com/klauspost/compress/zstd"
 	"go.uber.org/atomic"
+)
+
+const (
+	DefaultWSReadTimeout = 1 * time.Minute
 )
 
 type ClientConfig struct {
@@ -22,6 +27,7 @@ type ClientConfig struct {
 	WantedCollections []string
 	MaxSize           uint32
 	ExtraHeaders      map[string]string
+	ReadTimeout       time.Duration
 }
 
 type Scheduler interface {
@@ -46,6 +52,7 @@ func DefaultClientConfig() *ClientConfig {
 		WebsocketURL:      "ws://localhost:6008/subscribe",
 		WantedDids:        []string{},
 		WantedCollections: []string{},
+		ReadTimeout:       DefaultWSReadTimeout,
 		MaxSize:           0,
 		ExtraHeaders: map[string]string{
 			"User-Agent": "jetstream-client/v0.0.1",
@@ -151,6 +158,7 @@ func (c *Client) readLoop(ctx context.Context) error {
 			s <- struct{}{}
 			return nil
 		default:
+			c.con.SetReadDeadline(time.Now().Add(c.config.ReadTimeout))
 			_, msg, err := c.con.ReadMessage()
 			if err != nil {
 				c.logger.Error("failed to read message from websocket", "error", err)


### PR DESCRIPTION
The default one for some reason is 15 minutes which is inappropriate, see the screenshot

This PR also fixes a panic when client config is passed without `ExtraHeaders` initialized

```
time=2025-05-13T04:29:16.882Z level=INFO msg="starting websocket read loop" component=bluesky.Subscriber component=jetstream-client
time=2025-05-13T04:48:35.411Z level=ERROR msg="failed to read message from websocket" component=bluesky.Subscriber component=jetstream-client error="read tcp 10.42.1.35:36668->15.204.205.145:443: read: connection timed out"
time=2025-05-13T04:48:35.913Z level=INFO msg="connecting to websocket" component=bluesky.Subscriber component=jetstream-client url="wss://jetstream2.us-east.bsky.network/subscribe?cursor=1746981368006337"
time=2025-05-13T04:48:38.311Z level=INFO msg="starting websocket read loop" component=bluesky.Subscriber component=jetstream-client
```
![image](https://github.com/user-attachments/assets/1216479e-4bdf-4701-aa1e-784e38a2c90f)
